### PR TITLE
Halves the untrained pointing cooldown

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -385,7 +385,7 @@
 	if(ishuman(mob))
 		squad = mob.assigned_squad
 	if(!check_improved_pointing()) //Squad Leaders and above have reduced cooldown and get a bigger arrow
-		recently_pointed_to = world.time + 50
+		recently_pointed_to = world.time + 25
 		new /obj/effect/overlay/temp/point(T, src, A)
 	else
 		recently_pointed_to = world.time + 10


### PR DESCRIPTION
# About the pull request

pointing cooldown now = 25 vs 50 ticks prior, leadership cooldown remains at 10 and with big arrows

# Explain why it's good for the game

as it stands, the pointing cooldown of 50 is awkwardly long, and while it prevents spamming it also negatively impacts tactical awareness and easy non-verbal communication

halved cooldown should still prevent spamming, shouldn't outclass the pointing abilities of leaders, but allow for more efficient communication (especially for indicating cross-referencing between 2 pointed-at objects)

# Testing Photographs and Procedure

it's just a constant edit

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: halved the untrained pointing cooldown
/:cl:
